### PR TITLE
Consistent use of DLR MALSPP implementation version.

### DIFF
--- a/MOIMS_TESTBED_MALSPP/pom.xml
+++ b/MOIMS_TESTBED_MALSPP/pom.xml
@@ -355,7 +355,7 @@
         <org.ccsds.moims.mo.testbed.local.configuration.dir>target/deployment/cnes</org.ccsds.moims.mo.testbed.local.configuration.dir>
         <org.ccsds.moims.mo.testbed.remote.configuration.dir>target/deployment/dlr</org.ccsds.moims.mo.testbed.remote.configuration.dir>
         <org.ccsds.moims.mo.testbed.remote.classpath.filter>cnes-mal</org.ccsds.moims.mo.testbed.remote.classpath.filter>
-        <org.ccsds.moims.mo.testbed.remote.classpath.maven>int.esa.ccsds.mo:API_MAL:${esa.api.version},int.esa.ccsds.mo:MAL_IMPL:${esa.impl.version},int.esa.ccsds.mo:API_MAL_TEST:${esa.mal.test_api.version},de.dlr.gsoc:MO_MALSPP_TRANSPORT:1.0,de.dlr.gsoc:MO_MALSPP_ENCODING:1.0</org.ccsds.moims.mo.testbed.remote.classpath.maven>
+        <org.ccsds.moims.mo.testbed.remote.classpath.maven>int.esa.ccsds.mo:API_MAL:${esa.api.version},int.esa.ccsds.mo:MAL_IMPL:${esa.impl.version},int.esa.ccsds.mo:API_MAL_TEST:${esa.mal.test_api.version},de.dlr.gsoc:MO_MALSPP_TRANSPORT:1.0.2,de.dlr.gsoc:MO_MALSPP_ENCODING:1.0.2</org.ccsds.moims.mo.testbed.remote.classpath.maven>
       </properties>
     </profile>
     <profile>
@@ -377,12 +377,12 @@
         <dependency>
           <groupId>de.dlr.gsoc</groupId>
           <artifactId>MO_MALSPP_TRANSPORT</artifactId>
-          <version>1.0</version>
+          <version>1.0.2</version>
         </dependency>
         <dependency>
           <groupId>de.dlr.gsoc</groupId>
           <artifactId>MO_MALSPP_ENCODING</artifactId>
-          <version>1.0</version>
+          <version>1.0.2</version>
         </dependency>
         <dependency>
           <groupId>org.ow2.joram</groupId>


### PR DESCRIPTION
Not all version numbers for the DLR MALSPP implementation where updated to the latest version. This is just a quick fix. A better solution using properties will be implemented if I find some time.