### PR TITLE
Added ZMTP binding tests and fixed TCPIP binding tests

### DIFF
--- a/MOIMS_TESTBED_MAL/pom.xml
+++ b/MOIMS_TESTBED_MAL/pom.xml
@@ -765,6 +765,33 @@
         <org.ccsds.moims.mo.testbed.remote.configuration.dir>target/deployment/dlr</org.ccsds.moims.mo.testbed.remote.configuration.dir>
       </properties>
     </profile>
+    <profile>
+      <id>ESA_ZMTP</id>
+      <dependencies>
+        <dependency>
+          <groupId>int.esa.ccsds.mo</groupId>
+          <artifactId>API_MAL_TEST</artifactId>
+          <version>${esa.mal.test_api.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>int.esa.ccsds.mo</groupId>
+          <artifactId>API_MAL</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>int.esa.ccsds.mo</groupId>
+          <artifactId>MAL_IMPL</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>int.esa.ccsds.mo</groupId>
+          <artifactId>TRANSPORT_ZMTP</artifactId>
+          <version>1.0-SNAPSHOT</version>
+        </dependency>
+      </dependencies>
+      <properties>
+        <org.ccsds.moims.mo.testbed.local.configuration.dir>target/deployment/esa-zmtp</org.ccsds.moims.mo.testbed.local.configuration.dir>
+        <org.ccsds.moims.mo.testbed.remote.configuration.dir>target/deployment/esa-zmtp</org.ccsds.moims.mo.testbed.remote.configuration.dir>
+      </properties>
+    </profile>
   </profiles>
 </project>
 

--- a/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-tcpip/BaseLocalMALInstanceEnv.properties
+++ b/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-tcpip/BaseLocalMALInstanceEnv.properties
@@ -25,5 +25,6 @@ org.ccsds.moims.mo.mal.factory.class=esa.mo.mal.impl.MALContextFactoryImpl
 org.ccsds.moims.mo.mal.transport.protocol.tcpip=esa.mo.mal.transport.tcpip.TCPIPTransportFactoryImpl
 org.ccsds.moims.mo.mal.encoding.protocol.tcpip=esa.mo.mal.encoder.binary.split.SplitBinaryStreamFactory
 
-org.ccsds.moims.mo.mal.transport.tcpip.port=61627
-org.ccsds.moims.mo.mal.transport.tcpip.host=localhost
+#org.ccsds.moims.mo.mal.transport.tcpip.port=61627
+#org.ccsds.moims.mo.mal.transport.tcpip.host=localhost
+org.ccsds.moims.mo.mal.transport.tcpip.autohost=true

--- a/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-tcpip/BaseLocalMALInstanceMAL.properties
+++ b/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-tcpip/BaseLocalMALInstanceMAL.properties
@@ -18,5 +18,6 @@
 # limitations under the License. 
 # ----------------------------------------------------------------------------
 
-org.ccsds.moims.mo.mal.transport.tcpip.port=61627
-org.ccsds.moims.mo.mal.transport.tcpip.host=localhost
+#org.ccsds.moims.mo.mal.transport.tcpip.port=61627
+#org.ccsds.moims.mo.mal.transport.tcpip.host=localhost
+org.ccsds.moims.mo.mal.transport.tcpip.autohost=true

--- a/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-tcpip/BaseTestServiceProviderEnv.properties
+++ b/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-tcpip/BaseTestServiceProviderEnv.properties
@@ -25,5 +25,6 @@ org.ccsds.moims.mo.mal.factory.class=esa.mo.mal.impl.MALContextFactoryImpl
 org.ccsds.moims.mo.mal.transport.protocol.tcpip=esa.mo.mal.transport.tcpip.TCPIPTransportFactoryImpl
 org.ccsds.moims.mo.mal.encoding.protocol.tcpip=esa.mo.mal.encoder.binary.split.SplitBinaryStreamFactory
 
-org.ccsds.moims.mo.mal.transport.tcpip.port=61617
-org.ccsds.moims.mo.mal.transport.tcpip.host=localhost
+#org.ccsds.moims.mo.mal.transport.tcpip.port=61617
+#org.ccsds.moims.mo.mal.transport.tcpip.host=localhost
+org.ccsds.moims.mo.mal.transport.tcpip.autohost=true

--- a/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-tcpip/LocalMALInstanceEnv.properties
+++ b/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-tcpip/LocalMALInstanceEnv.properties
@@ -28,3 +28,5 @@ org.ccsds.moims.mo.mal.encoding.protocol.tcpip=esa.mo.mal.encoder.binary.split.S
 #org.ccsds.moims.mo.mal.encoding.protocol.tcpip=esa.mo.mal.encoder.string.StringStreamFactory
 #org.ccsds.moims.mo.mal.encoding.protocol.tcpip=esa.mo.mal.encoder.binary.BinaryStreamFactory
 #org.ccsds.moims.mo.mal.encoding.protocol.tcpip=esa.mo.mal.encoder.binary.fixed.FixedBinaryStreamFactory
+
+org.ccsds.moims.mo.mal.transport.tcpip.autohost=true

--- a/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-tcpip/LocalMALInstanceMAL.properties
+++ b/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-tcpip/LocalMALInstanceMAL.properties
@@ -20,3 +20,4 @@
 
 org.ccsds.moims.mo.mal.transport.gen.debug=false
 org.ccsds.moims.mo.mal.transport.gen.wrap=false
+org.ccsds.moims.mo.mal.transport.tcpip.autohost=true

--- a/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-tcpip/TestServiceProviderEnv.properties
+++ b/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-tcpip/TestServiceProviderEnv.properties
@@ -28,3 +28,4 @@ org.ccsds.moims.mo.mal.encoding.protocol.tcpip=esa.mo.mal.encoder.binary.split.S
 #org.ccsds.moims.mo.mal.encoding.protocol.tcpip=esa.mo.mal.encoder.string.StringStreamFactory
 #org.ccsds.moims.mo.mal.encoding.protocol.tcpip=esa.mo.mal.encoder.binary.BinaryStreamFactory
 #org.ccsds.moims.mo.mal.encoding.protocol.tcpip=esa.mo.mal.encoder.binary.fixed.FixedBinaryStreamFactory
+org.ccsds.moims.mo.mal.transport.tcpip.autohost=true

--- a/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-tcpip/TestServiceProviderMAL.properties
+++ b/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-tcpip/TestServiceProviderMAL.properties
@@ -20,3 +20,4 @@
 
 org.ccsds.moims.mo.mal.transport.gen.debug=false
 org.ccsds.moims.mo.mal.transport.gen.wrap=false
+org.ccsds.moims.mo.mal.transport.tcpip.autohost=true

--- a/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-zmtp/LocalMALInstanceEnv.properties
+++ b/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-zmtp/LocalMALInstanceEnv.properties
@@ -1,0 +1,32 @@
+# ----------------------------------------------------------------------------
+# Copyright (C) 2013      European Space Agency
+#                         European Space Operations Centre
+#                         Darmstadt
+#                         Germany
+# ----------------------------------------------------------------------------
+# System                : CCSDS MO MAL Test bed
+# ----------------------------------------------------------------------------
+# Licensed under the European Space Agency Public License, Version 2.0
+# You may not use this file except in compliance with the License.
+#
+# Except as expressly set forth in this License, the Software is provided to
+# You on an "as is" basis and without warranties of any kind, including without
+# limitation merchantability, fitness for a particular purpose, absence of
+# defects or errors, accuracy or non-infringement of intellectual property rights.
+# 
+# See the License for the specific language governing permissions and
+# limitations under the License. 
+# ----------------------------------------------------------------------------
+
+org.ccsds.moims.mo.testbed.transport.protocol=malzmtp
+org.ccsds.moims.mo.testbed.transport.factory=esa.mo.mal.transport.zmtp.ZMTPTransportFactoryImpl
+org.ccsds.moims.mo.mal.transport.protocol.malzmtp=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
+org.ccsds.moims.mo.mal.transport.protocol.test=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
+org.ccsds.moims.mo.mal.transport.protocol.test2=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
+
+#org.ccsds.moims.mo.mal.encoding.protocol.malzmtp=esa.mo.mal.encoder.zmtp.body.ZMTPBinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.malzmtp=esa.mo.mal.encoder.zmtp.body.ZMTPFixedBinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.malzmtp=esa.mo.mal.encoder.zmtp.body.ZMTPSplitBinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.malzmtp=esa.mo.mal.encoder.binary.fixed.FixedBinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.malzmtp=esa.mo.mal.encoder.binary.variable.VariableBinaryStreamFactory
+org.ccsds.moims.mo.mal.encoding.protocol.malzmtp=esa.mo.mal.encoder.binary.split.SplitBinaryStreamFactory

--- a/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-zmtp/LocalMALInstanceMAL.properties
+++ b/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-zmtp/LocalMALInstanceMAL.properties
@@ -1,0 +1,43 @@
+# ----------------------------------------------------------------------------
+# Copyright (C) 2013      European Space Agency
+#                         European Space Operations Centre
+#                         Darmstadt
+#                         Germany
+# ----------------------------------------------------------------------------
+# System                : CCSDS MO MAL Test bed
+# ----------------------------------------------------------------------------
+# Licensed under the European Space Agency Public License, Version 2.0
+# You may not use this file except in compliance with the License.
+#
+# Except as expressly set forth in this License, the Software is provided to
+# You on an "as is" basis and without warranties of any kind, including without
+# limitation merchantability, fitness for a particular purpose, absence of
+# defects or errors, accuracy or non-infringement of intellectual property rights.
+# 
+# See the License for the specific language governing permissions and
+# limitations under the License. 
+# ----------------------------------------------------------------------------
+
+org.ccsds.moims.mo.mal.transport.gen.debug=false
+org.ccsds.moims.mo.mal.transport.gen.wrap=false
+
+#org.ccsds.moims.mo.mal.encoding.protocol.malzmtp=esa.mo.mal.encoder.zmtp.body.ZMTPBinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.malzmtp=esa.mo.mal.encoder.zmtp.body.ZMTPFixedBinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.malzmtp=esa.mo.mal.encoder.zmtp.body.ZMTPSplitBinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.malzmtp=esa.mo.mal.encoder.binary.fixed.FixedBinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.malzmtp=esa.mo.mal.encoder.binary.variable.VariableBinaryStreamFactory
+org.ccsds.moims.mo.mal.encoding.protocol.malzmtp=esa.mo.mal.encoder.binary.split.SplitBinaryStreamFactory
+
+
+# Path to mapping directory file
+#org.ccsds.moims.mo.mal.transport.zmtp.mappingdirectoryfile=mappingDirectory.txt
+# Local base URI (if not specified then it is bound to localhost with a random port)
+#org.ccsds.moims.mo.mal.transport.zmtp.localuri=zmtp://localhost:61618
+
+## QoS properties for outbound messages (can be also configured dynamically by the software stack)
+org.ccsds.moims.mo.mal.transport.zmtp.authenticationid.flag=true
+org.ccsds.moims.mo.mal.transport.zmtp.domain.flag=true
+org.ccsds.moims.mo.mal.transport.zmtp.networkzone.flag=true
+org.ccsds.moims.mo.mal.transport.zmtp.priority.flag=true
+org.ccsds.moims.mo.mal.transport.zmtp.sessionname.flag=true
+org.ccsds.moims.mo.mal.transport.zmtp.timestamp.flag=true

--- a/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-zmtp/TestServiceProviderEnv.properties
+++ b/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-zmtp/TestServiceProviderEnv.properties
@@ -1,0 +1,33 @@
+# ----------------------------------------------------------------------------
+# Copyright (C) 2013      European Space Agency
+#                         European Space Operations Centre
+#                         Darmstadt
+#                         Germany
+# ----------------------------------------------------------------------------
+# System                : CCSDS MO MAL Test bed
+# ----------------------------------------------------------------------------
+# Licensed under the European Space Agency Public License, Version 2.0
+# You may not use this file except in compliance with the License.
+#
+# Except as expressly set forth in this License, the Software is provided to
+# You on an "as is" basis and without warranties of any kind, including without
+# limitation merchantability, fitness for a particular purpose, absence of
+# defects or errors, accuracy or non-infringement of intellectual property rights.
+# 
+# See the License for the specific language governing permissions and
+# limitations under the License. 
+# ----------------------------------------------------------------------------
+
+org.ccsds.moims.mo.testbed.transport.protocol=malzmtp
+org.ccsds.moims.mo.testbed.transport.factory=esa.mo.mal.transport.zmtp.ZMTPTransportFactoryImpl
+org.ccsds.moims.mo.mal.transport.protocol.malzmtp=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
+org.ccsds.moims.mo.mal.transport.protocol.test=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
+org.ccsds.moims.mo.mal.transport.protocol.test2=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
+
+#org.ccsds.moims.mo.mal.encoding.protocol.malzmtp=esa.mo.mal.encoder.zmtp.body.ZMTPBinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.malzmtp=esa.mo.mal.encoder.zmtp.body.ZMTPFixedBinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.malzmtp=esa.mo.mal.encoder.zmtp.body.ZMTPSplitBinaryStreamFactory
+org.ccsds.moims.mo.mal.encoding.protocol.malzmtp=esa.mo.mal.encoder.binary.fixed.FixedBinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.malzmtp=esa.mo.mal.encoder.binary.variable.VariableBinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.malzmtp=esa.mo.mal.encoder.binary.split.SplitBinaryStreamFactory
+

--- a/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-zmtp/TestServiceProviderMAL.properties
+++ b/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-zmtp/TestServiceProviderMAL.properties
@@ -1,0 +1,42 @@
+# ----------------------------------------------------------------------------
+# Copyright (C) 2013      European Space Agency
+#                         European Space Operations Centre
+#                         Darmstadt
+#                         Germany
+# ----------------------------------------------------------------------------
+# System                : CCSDS MO MAL Test bed
+# ----------------------------------------------------------------------------
+# Licensed under the European Space Agency Public License, Version 2.0
+# You may not use this file except in compliance with the License.
+#
+# Except as expressly set forth in this License, the Software is provided to
+# You on an "as is" basis and without warranties of any kind, including without
+# limitation merchantability, fitness for a particular purpose, absence of
+# defects or errors, accuracy or non-infringement of intellectual property rights.
+# 
+# See the License for the specific language governing permissions and
+# limitations under the License. 
+# ----------------------------------------------------------------------------
+
+org.ccsds.moims.mo.mal.transport.gen.debug=false
+org.ccsds.moims.mo.mal.transport.gen.wrap=false
+
+#org.ccsds.moims.mo.mal.encoding.protocol.malzmtp=esa.mo.mal.encoder.zmtp.body.ZMTPBinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.malzmtp=esa.mo.mal.encoder.zmtp.body.ZMTPFixedBinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.malzmtp=esa.mo.mal.encoder.zmtp.body.ZMTPSplitBinaryStreamFactory
+org.ccsds.moims.mo.mal.encoding.protocol.malzmtp=esa.mo.mal.encoder.binary.fixed.FixedBinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.malzmtp=esa.mo.mal.encoder.binary.variable.VariableBinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.malzmtp=esa.mo.mal.encoder.binary.split.SplitBinaryStreamFactory
+
+# Path to mapping directory file
+#org.ccsds.moims.mo.mal.transport.zmtp.mappingdirectoryfile=mappingDirectory.txt
+# Local base URI (if not specified then it is bound to localhost with a random port)
+org.ccsds.moims.mo.mal.transport.zmtp.localuri=zmtp://localhost:61620
+
+## QoS properties for outbound messages (can be also configured dynamically by the software stack)
+org.ccsds.moims.mo.mal.transport.zmtp.authenticationid.flag=true
+org.ccsds.moims.mo.mal.transport.zmtp.domain.flag=true
+org.ccsds.moims.mo.mal.transport.zmtp.networkzone.flag=true
+org.ccsds.moims.mo.mal.transport.zmtp.priority.flag=true
+org.ccsds.moims.mo.mal.transport.zmtp.sessionname.flag=true
+org.ccsds.moims.mo.mal.transport.zmtp.timestamp.flag=true


### PR DESCRIPTION
Created ZMTP binding tests.
Updated TCPIP test configuration, enabling the new _autohost_ functionality. This solves an error being a result of multiple MAL stacks trying to bind to the same TCPIP port.