### PR TITLE
Adapt to Binary Encoding and TCPIP changes

### DIFF
--- a/MOIMS_TESTBED_MAL/src/main/resources/deployment/dlr/LocalMALInstanceEnv.properties
+++ b/MOIMS_TESTBED_MAL/src/main/resources/deployment/dlr/LocalMALInstanceEnv.properties
@@ -11,7 +11,7 @@ org.ccsds.moims.mo.mal.transport.protocol.malspp=org.ccsds.moims.mo.testbed.tran
 org.ccsds.moims.mo.mal.transport.protocol.test=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
 org.ccsds.moims.mo.mal.transport.protocol.test2=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
 
-#org.ccsds.moims.mo.mal.encoding.protocol.rmi=esa.mo.mal.encoder.binary.BinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.rmi=esa.mo.mal.encoder.binary.variable.VariableBinaryStreamFactory
 #org.ccsds.moims.mo.mal.encoding.protocol.rmi=de.dlr.gsoc.mo.malspp.encoding.SPPElementStreamFactory
 org.ccsds.moims.mo.mal.encoding.protocol.malspp=de.dlr.gsoc.mo.malspp.encoding.SPPElementStreamFactory
 

--- a/MOIMS_TESTBED_MAL/src/main/resources/deployment/dlr/TestServiceProviderEnv.properties
+++ b/MOIMS_TESTBED_MAL/src/main/resources/deployment/dlr/TestServiceProviderEnv.properties
@@ -11,7 +11,7 @@ org.ccsds.moims.mo.mal.transport.protocol.malspp=org.ccsds.moims.mo.testbed.tran
 org.ccsds.moims.mo.mal.transport.protocol.test=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
 org.ccsds.moims.mo.mal.transport.protocol.test2=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
 
-#org.ccsds.moims.mo.mal.encoding.protocol.rmi=esa.mo.mal.encoder.binary.BinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.rmi=esa.mo.mal.encoder.binary.variable.VariableBinaryStreamFactory
 #org.ccsds.moims.mo.mal.encoding.protocol.rmi=de.dlr.gsoc.mo.malspp.encoding.SPPElementStreamFactory
 org.ccsds.moims.mo.mal.encoding.protocol.malspp=de.dlr.gsoc.mo.malspp.encoding.SPPElementStreamFactory
 

--- a/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-jms/LocalMALInstanceEnv.properties
+++ b/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-jms/LocalMALInstanceEnv.properties
@@ -25,7 +25,7 @@ org.ccsds.moims.mo.mal.transport.protocol.test=org.ccsds.moims.mo.testbed.transp
 org.ccsds.moims.mo.mal.transport.protocol.test2=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
 
 org.ccsds.moims.mo.mal.encoding.protocol.ccsdsjms=esa.mo.mal.encoder.string.StringStreamFactory
-#org.ccsds.moims.mo.mal.encoding.protocol.ccsdsjms=esa.mo.mal.encoder.binary.BinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.ccsdsjms=esa.mo.mal.encoder.binary.variable.VariableBinaryStreamFactory
 #org.ccsds.moims.mo.mal.encoding.protocol.ccsdsjms=esa.mo.mal.encoder.binary.split.SplitBinaryStreamFactory
 #org.ccsds.moims.mo.mal.encoding.protocol.ccsdsjms=esa.mo.mal.encoder.binary.fixed.FixedBinaryStreamFactory
 

--- a/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-jms/TestServiceProviderEnv.properties
+++ b/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-jms/TestServiceProviderEnv.properties
@@ -25,7 +25,7 @@ org.ccsds.moims.mo.mal.transport.protocol.test=org.ccsds.moims.mo.testbed.transp
 org.ccsds.moims.mo.mal.transport.protocol.test2=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
 
 org.ccsds.moims.mo.mal.encoding.protocol.ccsdsjms=esa.mo.mal.encoder.string.StringStreamFactory
-#org.ccsds.moims.mo.mal.encoding.protocol.ccsdsjms=esa.mo.mal.encoder.binary.BinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.ccsdsjms=esa.mo.mal.encoder.binary.variable.VariableBinaryStreamFactory
 #org.ccsds.moims.mo.mal.encoding.protocol.ccsdsjms=esa.mo.mal.encoder.binary.split.SplitBinaryStreamFactory
 #org.ccsds.moims.mo.mal.encoding.protocol.ccsdsjms=esa.mo.mal.encoder.binary.fixed.FixedBinaryStreamFactory
 

--- a/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-rmi/LocalMALInstanceEnv.properties
+++ b/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-rmi/LocalMALInstanceEnv.properties
@@ -25,6 +25,6 @@ org.ccsds.moims.mo.mal.transport.protocol.test=org.ccsds.moims.mo.testbed.transp
 org.ccsds.moims.mo.mal.transport.protocol.test2=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
 
 #org.ccsds.moims.mo.mal.encoding.protocol.rmi=esa.mo.mal.encoder.string.StringStreamFactory
-#org.ccsds.moims.mo.mal.encoding.protocol.rmi=esa.mo.mal.encoder.binary.BinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.rmi=esa.mo.mal.encoder.binary.variable.VariableBinaryStreamFactory
 #org.ccsds.moims.mo.mal.encoding.protocol.rmi=esa.mo.mal.encoder.binary.split.SplitBinaryStreamFactory
 org.ccsds.moims.mo.mal.encoding.protocol.rmi=esa.mo.mal.encoder.binary.fixed.FixedBinaryStreamFactory

--- a/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-rmi/TestServiceProviderEnv.properties
+++ b/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-rmi/TestServiceProviderEnv.properties
@@ -25,6 +25,6 @@ org.ccsds.moims.mo.mal.transport.protocol.test=org.ccsds.moims.mo.testbed.transp
 org.ccsds.moims.mo.mal.transport.protocol.test2=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
 
 #org.ccsds.moims.mo.mal.encoding.protocol.rmi=esa.mo.mal.encoder.string.StringStreamFactory
-#org.ccsds.moims.mo.mal.encoding.protocol.rmi=esa.mo.mal.encoder.binary.BinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.rmi=esa.mo.mal.encoder.binary.variable.VariableBinaryStreamFactory
 #org.ccsds.moims.mo.mal.encoding.protocol.rmi=esa.mo.mal.encoder.binary.split.SplitBinaryStreamFactory
 org.ccsds.moims.mo.mal.encoding.protocol.rmi=esa.mo.mal.encoder.binary.fixed.FixedBinaryStreamFactory

--- a/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-tcpip/BaseLocalMALInstanceEnv.properties
+++ b/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-tcpip/BaseLocalMALInstanceEnv.properties
@@ -18,12 +18,12 @@
 # limitations under the License. 
 # ----------------------------------------------------------------------------
 
-org.ccsds.moims.mo.mal.transport.default.protocol=tcpip
+org.ccsds.moims.mo.mal.transport.default.protocol=maltcp
 
 org.ccsds.moims.mo.mal.factory.class=esa.mo.mal.impl.MALContextFactoryImpl
 
-org.ccsds.moims.mo.mal.transport.protocol.tcpip=esa.mo.mal.transport.tcpip.TCPIPTransportFactoryImpl
-org.ccsds.moims.mo.mal.encoding.protocol.tcpip=esa.mo.mal.encoder.binary.split.SplitBinaryStreamFactory
+org.ccsds.moims.mo.mal.transport.protocol.maltcp=esa.mo.mal.transport.tcpip.TCPIPTransportFactoryImpl
+org.ccsds.moims.mo.mal.encoding.protocol.maltcp=esa.mo.mal.encoder.binary.split.SplitBinaryStreamFactory
 
 #org.ccsds.moims.mo.mal.transport.tcpip.port=61627
 #org.ccsds.moims.mo.mal.transport.tcpip.host=localhost

--- a/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-tcpip/BaseTestServiceProviderEnv.properties
+++ b/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-tcpip/BaseTestServiceProviderEnv.properties
@@ -18,12 +18,12 @@
 # limitations under the License. 
 # ----------------------------------------------------------------------------
 
-org.ccsds.moims.mo.mal.transport.default.protocol=tcpip
+org.ccsds.moims.mo.mal.transport.default.protocol=maltcp
 
 org.ccsds.moims.mo.mal.factory.class=esa.mo.mal.impl.MALContextFactoryImpl
 
-org.ccsds.moims.mo.mal.transport.protocol.tcpip=esa.mo.mal.transport.tcpip.TCPIPTransportFactoryImpl
-org.ccsds.moims.mo.mal.encoding.protocol.tcpip=esa.mo.mal.encoder.binary.split.SplitBinaryStreamFactory
+org.ccsds.moims.mo.mal.transport.protocol.maltcp=esa.mo.mal.transport.tcpip.TCPIPTransportFactoryImpl
+org.ccsds.moims.mo.mal.encoding.protocol.maltcp=esa.mo.mal.encoder.binary.split.SplitBinaryStreamFactory
 
 #org.ccsds.moims.mo.mal.transport.tcpip.port=61617
 #org.ccsds.moims.mo.mal.transport.tcpip.host=localhost

--- a/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-tcpip/LocalMALInstanceEnv.properties
+++ b/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-tcpip/LocalMALInstanceEnv.properties
@@ -18,15 +18,15 @@
 # limitations under the License. 
 # ----------------------------------------------------------------------------
 
-org.ccsds.moims.mo.testbed.transport.protocol=tcpip
+org.ccsds.moims.mo.testbed.transport.protocol=maltcp
 org.ccsds.moims.mo.testbed.transport.factory=esa.mo.mal.transport.tcpip.TCPIPTransportFactoryImpl
-org.ccsds.moims.mo.mal.transport.protocol.tcpip=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
+org.ccsds.moims.mo.mal.transport.protocol.maltcp=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
 org.ccsds.moims.mo.mal.transport.protocol.test=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
 org.ccsds.moims.mo.mal.transport.protocol.test2=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
 
-org.ccsds.moims.mo.mal.encoding.protocol.tcpip=esa.mo.mal.encoder.binary.split.SplitBinaryStreamFactory
-#org.ccsds.moims.mo.mal.encoding.protocol.tcpip=esa.mo.mal.encoder.string.StringStreamFactory
-#org.ccsds.moims.mo.mal.encoding.protocol.tcpip=esa.mo.mal.encoder.binary.BinaryStreamFactory
-#org.ccsds.moims.mo.mal.encoding.protocol.tcpip=esa.mo.mal.encoder.binary.fixed.FixedBinaryStreamFactory
+org.ccsds.moims.mo.mal.encoding.protocol.maltcp=esa.mo.mal.encoder.binary.split.SplitBinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.maltcp=esa.mo.mal.encoder.string.StringStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.maltcp=esa.mo.mal.encoder.binary.variable.VariableBinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.maltcp=esa.mo.mal.encoder.binary.fixed.FixedBinaryStreamFactory
 
 org.ccsds.moims.mo.mal.transport.tcpip.autohost=true

--- a/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-tcpip/TestServiceProviderEnv.properties
+++ b/MOIMS_TESTBED_MAL/src/main/resources/deployment/esa-tcpip/TestServiceProviderEnv.properties
@@ -18,14 +18,15 @@
 # limitations under the License. 
 # ----------------------------------------------------------------------------
 
-org.ccsds.moims.mo.testbed.transport.protocol=tcpip
+org.ccsds.moims.mo.testbed.transport.protocol=maltcp
 org.ccsds.moims.mo.testbed.transport.factory=esa.mo.mal.transport.tcpip.TCPIPTransportFactoryImpl
-org.ccsds.moims.mo.mal.transport.protocol.tcpip=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
+org.ccsds.moims.mo.mal.transport.protocol.maltcp=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
 org.ccsds.moims.mo.mal.transport.protocol.test=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
 org.ccsds.moims.mo.mal.transport.protocol.test2=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
 
-org.ccsds.moims.mo.mal.encoding.protocol.tcpip=esa.mo.mal.encoder.binary.split.SplitBinaryStreamFactory
-#org.ccsds.moims.mo.mal.encoding.protocol.tcpip=esa.mo.mal.encoder.string.StringStreamFactory
-#org.ccsds.moims.mo.mal.encoding.protocol.tcpip=esa.mo.mal.encoder.binary.BinaryStreamFactory
-#org.ccsds.moims.mo.mal.encoding.protocol.tcpip=esa.mo.mal.encoder.binary.fixed.FixedBinaryStreamFactory
+org.ccsds.moims.mo.mal.encoding.protocol.maltcp=esa.mo.mal.encoder.binary.split.SplitBinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.maltcp=esa.mo.mal.encoder.string.StringStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.maltcp=esa.mo.mal.encoder.binary.variable.VariableBinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.maltcp=esa.mo.mal.encoder.binary.split.SplitBinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.maltcp=esa.mo.mal.encoder.binary.fixed.FixedBinaryStreamFactory
 org.ccsds.moims.mo.mal.transport.tcpip.autohost=true

--- a/MOIMS_TESTBED_MALSPP/src/main/resources/deployment/dlr/LocalMALInstanceEnv.properties
+++ b/MOIMS_TESTBED_MALSPP/src/main/resources/deployment/dlr/LocalMALInstanceEnv.properties
@@ -11,7 +11,7 @@ org.ccsds.moims.mo.mal.transport.protocol.malspp=org.ccsds.moims.mo.testbed.tran
 #org.ccsds.moims.mo.mal.transport.protocol.test=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
 #org.ccsds.moims.mo.mal.transport.protocol.test2=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
 
-#org.ccsds.moims.mo.mal.encoding.protocol.rmi=esa.mo.mal.encoder.binary.BinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.rmi=esa.mo.mal.encoder.binary.variable.VariableBinaryStreamFactory
 #org.ccsds.moims.mo.mal.encoding.protocol.rmi=de.dlr.gsoc.mo.malspp.encoding.SPPElementStreamFactory
 org.ccsds.moims.mo.mal.encoding.protocol.malspp=de.dlr.gsoc.mo.malspp.encoding.SPPElementStreamFactory
 

--- a/MOIMS_TESTBED_MALSPP/src/main/resources/deployment/dlr/TestServiceProviderEnv.properties
+++ b/MOIMS_TESTBED_MALSPP/src/main/resources/deployment/dlr/TestServiceProviderEnv.properties
@@ -11,7 +11,7 @@ org.ccsds.moims.mo.mal.transport.protocol.malspp=org.ccsds.moims.mo.testbed.tran
 #org.ccsds.moims.mo.mal.transport.protocol.test=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
 #org.ccsds.moims.mo.mal.transport.protocol.test2=org.ccsds.moims.mo.testbed.transport.TestTransportFactory
 
-#org.ccsds.moims.mo.mal.encoding.protocol.rmi=esa.mo.mal.encoder.binary.BinaryStreamFactory
+#org.ccsds.moims.mo.mal.encoding.protocol.rmi=esa.mo.mal.encoder.binary.variable.VariableBinaryStreamFactory
 #org.ccsds.moims.mo.mal.encoding.protocol.rmi=de.dlr.gsoc.mo.malspp.encoding.SPPElementStreamFactory
 org.ccsds.moims.mo.mal.encoding.protocol.malspp=de.dlr.gsoc.mo.malspp.encoding.SPPElementStreamFactory
 


### PR DESCRIPTION
- Changed *.encoder.binary.BinaryStreamFactory to
  *.encoder.binary.variable.VariableBinaryStreamFactory
- Changed protocol prefix "tcpip://" to "maltcp://"


Please note that many changes modify comments and are done just for consistency and to avoid confusion.