### PR TITLE
Made the timeout configurable for PatternTest waiting for responses

### DIFF
--- a/MOIMS_TESTBED_MAL/src/main/java/org/ccsds/moims/mo/mal/test/patterns/PatternTest.java
+++ b/MOIMS_TESTBED_MAL/src/main/java/org/ccsds/moims/mo/mal/test/patterns/PatternTest.java
@@ -49,6 +49,7 @@ import org.ccsds.moims.mo.testbed.transport.TestMessageHeader;
 import org.ccsds.moims.mo.testbed.transport.TransportInterceptor;
 import org.ccsds.moims.mo.testbed.util.LoggingBase;
 import org.ccsds.moims.mo.testbed.util.ParseHelper;
+import org.ccsds.moims.mo.testbed.util.Configuration;
 
 /**
  *
@@ -278,7 +279,7 @@ public class PatternTest
     try
     {
       LoggingBase.logMessage("PatternTest.waiting for responses");
-      retVal = monitor.cond.waitFor(10000);
+      retVal = monitor.cond.waitFor(Configuration.WAIT_TIME_OUT);
     }
     catch (InterruptedException ex)
     {


### PR DESCRIPTION
This change allows to configure the timeout by using the configuration parameter org.ccsds.moims.mo.testbed.wait.timeout in the PatternTest as it is waiting for responses. This is in line with the use of the same parameter for other tests.
